### PR TITLE
Eliminated the warning message: "Interrupt triggered but zero messages" to avoid worring customers.

### DIFF
--- a/drivers/input/touchscreen/atmel_mxt_ts.c
+++ b/drivers/input/touchscreen/atmel_mxt_ts.c
@@ -1310,8 +1310,9 @@ static irqreturn_t mxt_process_messages_t44(struct mxt_data *data)
 		 * This condition is caused by the CHG line being configured
 		 * in Mode 0. It results in unnecessary I2C operations but it
 		 * is benign.
+         * Commented this message to avoid worrying customers.
 		 */
-		dev_dbg(dev, "Interrupt triggered but zero messages\n");
+		/* dev_dbg(dev, "Interrupt triggered but zero messages\n"); */
 		return IRQ_NONE;
 	} else if (count > data->max_reportid) {
 		dev_err(dev, "T44 count %d exceeded max report id\n", count);


### PR DESCRIPTION
Hi Nick,

As a local AE supporting customers, we found customers is always chasing us for this annoying warning message. So I suggest to eliminate it to avoid worrying customers.

janus.cheng@atmel.com
